### PR TITLE
Updated catalog url extracting logic

### DIFF
--- a/Nickvision.FlatpakGenerator/Program.cs
+++ b/Nickvision.FlatpakGenerator/Program.cs
@@ -117,7 +117,28 @@ public class Program
         using var httpClient = new HttpClient();
         var regResponse = await httpClient.GetAsync($"https://api.nuget.org/v3/registration5-semver1/{name}/index.json");
         var regObj = JsonSerializer.Deserialize<JsonObject>(await regResponse.Content.ReadAsStringAsync())!;
-        var catalogUrl = ((regObj["items"] as JsonArray)![^1]!["items"] as JsonArray)![^1]!["catalogEntry"]!["@id"]!.ToString();
+        string catalogUrl;
+        try
+        {
+            catalogUrl = ((regObj["items"] as JsonArray)![^1]!["items"] as JsonArray)![^1]!["catalogEntry"]!["@id"]!.ToString();
+        }
+        catch
+        {
+            try
+            {
+                var detailedResponseUrl = (regObj["items"] as JsonArray)![^1]!["@id"]!.ToString();
+                var detailedResponse = await httpClient.GetAsync(detailedResponseUrl);
+                var detailedResponseObj = JsonSerializer.Deserialize<JsonObject>(await detailedResponse.Content.ReadAsStringAsync())!;
+                catalogUrl = (detailedResponseObj["items"] as JsonArray)![^1]!["catalogEntry"]!["@id"]!.ToString();
+            }
+            catch(Exception e)
+            {
+                Console.WriteLine(e);
+                Console.WriteLine("Failed to parse catalog url for " + name);
+                Environment.Exit(1);
+                return null!;
+            }
+        }
         var catResponse = await httpClient.GetAsync(catalogUrl);
         var catObj = JsonSerializer.Deserialize<JsonObject>(await catResponse.Content.ReadAsStringAsync())!;
         var version = catObj["version"]!.ToString();

--- a/Nickvision.FlatpakGenerator/Program.cs
+++ b/Nickvision.FlatpakGenerator/Program.cs
@@ -115,8 +115,20 @@ public class Program
     {
         name = name.ToLower();
         using var httpClient = new HttpClient();
-        var regResponse = await httpClient.GetAsync($"https://api.nuget.org/v3/registration5-semver1/{name}/index.json");
-        var regObj = JsonSerializer.Deserialize<JsonObject>(await regResponse.Content.ReadAsStringAsync())!;
+        JsonObject regObj;
+        try
+        {
+            var regResponse = await httpClient.GetAsync($"https://api.nuget.org/v3/registration5-semver1/{name}/index.json");
+            var s = await regResponse.Content.ReadAsStringAsync();
+            regObj = JsonSerializer.Deserialize<JsonObject>(s)!;
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            Console.WriteLine("Failed to get package data for " + name);
+            Environment.Exit(1);
+            return null!;
+        }
         string catalogUrl;
         try
         {


### PR DESCRIPTION
Flatpak generator now fails on this url: https://api.nuget.org/v3/registration5-semver1/microsoft.netcore.app.runtime.linux-arm/index.json

Assumptions made here are wrong for some urls now:
```
            catalogUrl = ((regObj["items"] as JsonArray)![^1]!["items"] as JsonArray)![^1]!["catalogEntry"]!["@id"]!.ToString();
```
